### PR TITLE
Update workflow to new version that will allow a boolean to test

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -2,17 +2,25 @@ name: 'NPM Publish'
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      checkAuthOnly:
+          description: 'For checking that auth works'
+          required: true
+          type: choice
+          options: 
+            - yes
 
 jobs:
   NPM-Publish:
     permissions:
       contents: read
       id-token: write
-
-    uses: celo-org/reusable-workflows/.github/workflows/npm-publish.yaml@v1.11.1
+    uses: celo-org/reusable-workflows/.github/workflows/npm-publish.yaml@v2.0.4
     with:
       node-version: 16
       package-dir: 'packages/snap'
       akeyless-api-gateway: https://api.gateway.akeyless.celo-networks-dev.org
       akeyless-github-access-id: p-kf9vjzruht6l
       akeyless-token-path: /static-secrets/NPM/npm-publish-token
+      check-auth-only: ${{ inputs.checkAuthOnly == 'yes' && true || false  }}


### PR DESCRIPTION
Update workflow to new version that will set a boolean in the workflow dispatch, that if set will only try to pull the key from akeyless, and verify that the permissions work.  If ran through another method, will actually publish the npm package.

Calls https://github.com/celo-org/reusable-workflows/blob/main/.github/workflows/npm-publish.yaml which will check the input to see if this should just be a dry run to test the keys or publish the package.